### PR TITLE
Enable classes and switches flags for padded-blocks rule

### DIFF
--- a/baseConfig.json
+++ b/baseConfig.json
@@ -227,7 +227,7 @@
         "one-var-declaration-per-line": "off",
         "operator-assignment": [ "error", "always" ],
         "operator-linebreak": [ "error", "after" ],
-        "padded-blocks": [ "error", "never" ],
+        "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
         "prefer-arrow-callback": "off",
         "prefer-rest-params": "error",
         "quote-props": [ "error", "as-needed" ],


### PR DESCRIPTION
We already have padded-blocks set to "never" for blocks, so I suggest to also disallow padding in switches and classes for better consistency.