### PR TITLE
Increase version range of ESLint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "object-assign": "^4.0.1"
     },
     "peerDependencies": {
-        "eslint": "~2.5.3"
+        "eslint": "^2.5.3"
     },
     "devDependencies": {
         "chai": "3.5.0",


### PR DESCRIPTION
The initial idea behind having a small version range was to always enforce to update the configuration when updating to a new eslint minor version which might include new rules that are otherwise not configured.

Since ESLint doesn’t provide a default configuration anymore we won’t ran into a scenario where a minor update would enable rules without explicitly changing our configuration.

The increased version range should make dependency updates easier, especially if greenkeeper is doing that for you. So you don’t have to update both packages at once.