### PR TITLE
Revert "Enable `newline-before-return` rule"

### DIFF
--- a/baseConfig.json
+++ b/baseConfig.json
@@ -222,7 +222,7 @@
         "new-cap": "error",
         "new-parens": "error",
         "newline-after-var": [ "off", "always" ],
-        "newline-before-return": "error",
+        "newline-before-return": "off",
         "newline-per-chained-call": "off",
         "object-curly-spacing": [ "error", "always" ],
         "object-shorthand": "off",


### PR DESCRIPTION
Reverts holidaycheck/eslint-config-holidaycheck#17

Revert, as we decided that we don’t want to have this rule enabled.