### PR TITLE
Increase max-params Rule by 1

### DIFF
--- a/baseConfig.json
+++ b/baseConfig.json
@@ -223,7 +223,7 @@
         "max-len": [ "error", 120, 4 ],
         "max-lines": "off",
         "max-nested-callbacks": [ "error", 3 ],
-        "max-params": [ "error", 4 ],
+        "max-params": [ "error", 5 ],
         "max-statements": [ "error", 10 ],
         "multiline-ternary": "off",
         "max-statements-per-line": "off",


### PR DESCRIPTION
Currently the `max-params` rule ([docs](http://eslint.org/docs/rules/max-params)) is set to `4`. 
With this PR I propose to increase the maximum amount of parameters of functions to `5`. 

**Motivation**
We use fluxible and its plugin fetcher. The [API](https://github.com/yahoo/fluxible/blob/master/packages/fluxible-plugin-fetchr/docs/fluxible-plugin-fetchr.md#actioncontext-methods) provides an `actionContext.service.create` function which can have 5 parameters. We shouldn't throw linting errors for functions from packages we rely on.

What do you think?