### PR TITLE
Disable prefer-rest-params for ES5 config

### DIFF
--- a/baseConfig.json
+++ b/baseConfig.json
@@ -242,7 +242,7 @@
         "operator-linebreak": [ "error", "after" ],
         "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
         "prefer-arrow-callback": "off",
-        "prefer-rest-params": "error",
+        "prefer-rest-params": "off",
         "quote-props": [ "error", "as-needed" ],
         "quotes": [ "error", "single" ],
         "radix": "error",

--- a/es2015/es2015BaseConfig.js
+++ b/es2015/es2015BaseConfig.js
@@ -33,7 +33,8 @@ config.rules = assign({}, config.rules, {
     'prefer-template': 'error',
     'require-yield': 'error',
     'no-useless-rename': 'error',
-    'rest-spread-spacing': [ 'error', 'never' ]
+    'rest-spread-spacing': [ 'error', 'never' ],
+    'prefer-rest-params': 'error'
 });
 
 module.exports = function () {


### PR DESCRIPTION
Rest params are not available in ES5, so they should be only used in ES2015 config