### PR TITLE
Update node.js versions for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "4"
-  - "5"
+  - "6"
+  - "7"
 notifications:
    email: false


### PR DESCRIPTION
This remove node.js 5 and adds node.js 6 and 7 as build environments for travis.